### PR TITLE
Update p2pp.sh

### DIFF
--- a/p2pp.sh
+++ b/p2pp.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 DIRECTORY=`dirname $0`
-$DIRECTORY/P2PP.py -i $1
+$DIRECTORY/P2PP.py -i "$1"


### PR DESCRIPTION
p2pp.sh does not work when the first stl filename imported contains space character, such as  "my project.stl". Only the first word is recognised by the script causing "O" commands on output gcode not appearing. To fix this issue, $1 input variable should be enclosed with double quotes.