### PR TITLE
Feature/fix paths with spaces

### DIFF
--- a/p2pp.sh
+++ b/p2pp.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 DIRECTORY=`dirname $0`
-$DIRECTORY/P2PP.py -i $1
+$DIRECTORY/P2PP.py -i "$1"


### PR DESCRIPTION
Very simple change =] When you use $1 without quotes around it you split any paths with spaces into multiple arguments; simple mistake, easy to make. It took me some time to figure out what was going on. Now that I have this submitted I'll go try my first print with p2pp =]