### PR TITLE
Fix wipe tower gcode when not using sidewupe

### DIFF
--- a/p2pp/mcf.py
+++ b/p2pp/mcf.py
@@ -83,6 +83,8 @@ def gcode_filter_toolchange_block(line):
 
 
 def coordinate_on_bed(x, y):
+    if not v.side_wipe
+        return True
     if (v.bed_origin_x > x):
         return False
     if (x >= v.bed_origin_x + v.bed_size_x):


### PR DESCRIPTION
Using a printer with a size larger than the MK2 or MK3 (in my case 300x300) without enabling sidewipe can cause the tower to have needed extrusions removed by the coordinate_on_bed function since the BEDSIZEX and BEDSIZEY values are likely omitted (and default).

Alternatively the documentation could be updated to make setting these values obligatory as opposed to optional parameters for side wipe.