### PR TITLE
Fix unretract behaviour (G11, and G1 based)

### DIFF
--- a/p2pp/mcf.py
+++ b/p2pp/mcf.py
@@ -147,6 +147,7 @@ def entertower(layer_hght):
         v.processed_gcode.append(";------------------------------\n")
         v.processed_gcode.append(";  P2PP DELTA >> TOWER {:.2f}mm\n".format(
             purgeheight))
+
         purgetower.retract(v.current_tool)
 
         v.processed_gcode.append(
@@ -469,7 +470,31 @@ def gcode_parseline(index):
                 g.remove_parameter("E")
             else:
                 g.move_to_comment("tool unload")
-
+            if g.is_movement_command():
+                if not (g.has_parameter("Z")):
+                    g.move_to_comment("tool unload")
+                else:
+                    g.remove_parameter("X")
+                    g.remove_parameter("Y")
+                    g.remove_parameter("F")
+                    g.remove_parameter("E")
+            if g.is_unretract_command():
+                v.retracted = True
+                g.move_to_comment("tool unload")
+        else:
+            if g.fullcommand == "G4":
+                g.move_to_comment("tool unload")
+            if g.is_movement_command():
+                if g.has_parameter("Z"):
+                    g.remove_parameter("X")
+                    g.remove_parameter("Y")
+                    g.remove_parameter("F")
+                    g.remove_parameter("E")
+                else:
+                    g.move_to_comment("tool unload")
+            if g.is_unretract_command():
+                v.retracted = True
+                g.move_to_comment("tool unload")
         g.issue_command()
         return
 
@@ -619,6 +644,7 @@ def gcode_parseline(index):
 
             v.processed_gcode.append(
                 "G1 X{:.3f} Y{:.3f}; P2PP Inserted to realign\n".format(v.purge_keep_x, v.purge_keep_y))
+
             v.current_position_x = _x
             v.current_position_x = _y
 

--- a/p2pp/mcf.py
+++ b/p2pp/mcf.py
@@ -682,7 +682,7 @@ def gcode_parseline(index):
 
     # check here issue with unretract
     #################################
-    if (g.X or g.Y) and v.retracted:
+    if (g.X or g.Y) and g.E > 0 and v.retracted:
         purgetower.unretract(v.current_tool)
         v.retracted = False
 

--- a/p2pp/mcf.py
+++ b/p2pp/mcf.py
@@ -460,9 +460,10 @@ def gcode_parseline(index):
 
         if g.fullcommand == "G4":
             g.move_to_comment("tool unload")
+        if g.is_unretract_command():
+            v.retracted = True
+            g.move_to_comment("tool unload")
         if g.is_movement_command():
-            if g.is_unretract_command():
-                v.retracted = True
             if g.has_parameter("Z"):
                 g.remove_parameter("X")
                 g.remove_parameter("Y")
@@ -470,31 +471,7 @@ def gcode_parseline(index):
                 g.remove_parameter("E")
             else:
                 g.move_to_comment("tool unload")
-            if g.is_unretract_command():
-                v.retracted = True
-                g.move_to_comment("tool unload")
-            if g.is_movement_command():
-                if not (g.has_parameter("Z")):
-                    g.move_to_comment("tool unload")
-                else:
-                    g.remove_parameter("X")
-                    g.remove_parameter("Y")
-                    g.remove_parameter("F")
-                    g.remove_parameter("E")
-        else:
-            if g.fullcommand == "G4":
-                g.move_to_comment("tool unload")
-            if g.is_unretract_command():
-                v.retracted = True
-                g.move_to_comment("tool unload")
-            if g.is_movement_command():
-                if g.has_parameter("Z"):
-                    g.remove_parameter("X")
-                    g.remove_parameter("Y")
-                    g.remove_parameter("F")
-                    g.remove_parameter("E")
-                else:
-                    g.move_to_comment("tool unload")
+            
         g.issue_command()
         return
 

--- a/p2pp/mcf.py
+++ b/p2pp/mcf.py
@@ -460,10 +460,10 @@ def gcode_parseline(index):
 
         if g.fullcommand == "G4":
             g.move_to_comment("tool unload")
-        if g.is_unretract_command():
-            v.retracted = True
-            g.move_to_comment("tool unload")
         if g.is_movement_command():
+            if g.is_unretract_command():
+                v.retracted = True
+                g.move_to_comment("tool unload")
             if g.has_parameter("Z"):
                 g.remove_parameter("X")
                 g.remove_parameter("Y")

--- a/p2pp/mcf.py
+++ b/p2pp/mcf.py
@@ -470,6 +470,9 @@ def gcode_parseline(index):
                 g.remove_parameter("E")
             else:
                 g.move_to_comment("tool unload")
+            if g.is_unretract_command():
+                v.retracted = True
+                g.move_to_comment("tool unload")
             if g.is_movement_command():
                 if not (g.has_parameter("Z")):
                     g.move_to_comment("tool unload")
@@ -478,11 +481,11 @@ def gcode_parseline(index):
                     g.remove_parameter("Y")
                     g.remove_parameter("F")
                     g.remove_parameter("E")
-            if g.is_unretract_command():
-                v.retracted = True
-                g.move_to_comment("tool unload")
         else:
             if g.fullcommand == "G4":
+                g.move_to_comment("tool unload")
+            if g.is_unretract_command():
+                v.retracted = True
                 g.move_to_comment("tool unload")
             if g.is_movement_command():
                 if g.has_parameter("Z"):
@@ -492,9 +495,6 @@ def gcode_parseline(index):
                     g.remove_parameter("E")
                 else:
                     g.move_to_comment("tool unload")
-            if g.is_unretract_command():
-                v.retracted = True
-                g.move_to_comment("tool unload")
         g.issue_command()
         return
 


### PR DESCRIPTION
When running a file compare between G1 and G10 based retraction output with the recent fixes, I noticed a case where unretract behaviour was broken. For G1 retractions, it wouldn't unretract in relative mode, or over-extrude in absolute mode following the purge tower move. In the case of firmware retractions it would issue the G11 before the re-alignment move. See photo.

![Missing or Bad Retract](https://user-images.githubusercontent.com/1007595/68552991-51098e00-03eb-11ea-8cc7-c2399ff493a9.png)

There was a secondary issue where the previous change I made didn't add the \n to the firmware retraction commands, also fixed here.

Validated with file compare, results files attached

[Test Results.zip](https://github.com/tomvandeneede/p2pp/files/3829227/Test.Results.zip)
