### PR TITLE
Check "nexttools" length before trying to access [0]; fixes crash whe…

### DIFF
--- a/p2pp/p2_m4c.py
+++ b/p2pp/p2_m4c.py
@@ -88,8 +88,11 @@ def calculate_loadscheme():
     for idx in range(len(v.m4c_toolchanges)):
         nexttools.append(calc_next(-1, v.m4c_toolchanges[idx:]))
 
-    loadedinputs = deepcopy(nexttools[0][:4])
-    loadedinputs.sort()
+    if len(nexttools) > 0:
+        loadedinputs = deepcopy(nexttools[0][:4])
+        loadedinputs.sort()
+    else:
+        loadedinputs = []
 
     for idx in range(len(v.m4c_toolchanges) - 2):
 


### PR DESCRIPTION
Ran into a bug trying to use a specific color with my palette 2s pro; the post-processor crashed. I know I could have just bypassed the palette, but didn't want to pull it all out. this fixed it and it correctly gave me warnings instead of crashing =]