### PR TITLE
Add support for klipper flavored gcode

### DIFF
--- a/p2pp/mcf.py
+++ b/p2pp/mcf.py
@@ -349,6 +349,18 @@ def gcode_parselines():
                 if not v.debug_leaveToolCommands:
                     gcode.move_to_comment(g, "--P2PP-- Color Change")
                     v.toolchange_processed = True
+            elif g[gcode.COMMAND] == 'ACTIVATE_EXTRUDER':
+                extruder = gcode.get_parameter(g, gcode. OTHER, None)
+                extruder_num = None
+                if extruder == ' EXTRUDER=extruder':
+                    extruder_num = 0
+                elif extruder.startswith(' EXTRUDER=extruder'):
+                    extruder_num = int(extruder[18:])
+                if extruder_num is not None:
+                    gcode_process_toolchange(extruder_num)
+                if not v.debug_leaveToolCommands:
+                    gcode.move_to_comment(g, "--P2PP-- Color Change")
+                    v.toolchange_processed = True
             else:
                 if current_block_class == CLS_TOOL_UNLOAD:
                     if g[gcode.COMMAND] in ["G4", "M900"]:


### PR DESCRIPTION
When testing p2pp with Superslicer set to klipper flavored gcode, p2pp fails to recognize the gcode as a multi-color print, because the gcode for switching extruders is different than normal marlin/etc.  This adds support for the klipper `ACTIVATE_EXTRUDER` command that is the equivalent of the T0/Tx commands.

One thing to note, I have tested that this recognizes and processes klipper flavored gcode, but I haven't tested possible klipper related issues because the splice core in my Palette died right before I was able to print with a p2pp processed file.